### PR TITLE
Add a variable for datastore for easier importing to grafana

### DIFF
--- a/grafana/provisioning/dashboards/monad-monitoring-v2.json
+++ b/grafana/provisioning/dashboards/monad-monitoring-v2.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
+  "id": 22,
   "links": [],
   "panels": [
     {
@@ -38,7 +38,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Busy state of all CPU cores together",
       "fieldConfig": {
@@ -91,9 +91,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -107,7 +105,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -177,9 +175,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -193,7 +189,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -264,9 +260,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -280,7 +274,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -341,9 +335,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -357,7 +349,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -374,7 +366,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "100 - ((node_memory_MemAvailable_bytes * 100) / node_memory_MemTotal_bytes)",
@@ -443,9 +435,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -459,7 +449,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -480,7 +470,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Used Root FS",
       "fieldConfig": {
@@ -533,9 +523,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -549,7 +537,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -620,9 +608,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -636,7 +622,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -703,9 +689,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -719,7 +703,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -786,9 +770,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -802,7 +784,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -869,9 +851,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -885,7 +865,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -1094,7 +1074,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -1111,7 +1091,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1128,7 +1108,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1144,7 +1124,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1160,7 +1140,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1176,7 +1156,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1634,7 +1614,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -1651,7 +1631,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "node_memory_MemTotal_bytes - node_memory_MemFree_bytes - (node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes  )",
@@ -1666,7 +1646,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes",
@@ -1680,7 +1660,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "node_memory_MemFree_bytes",
@@ -1694,7 +1674,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "(node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes)",
@@ -1796,7 +1776,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -2244,7 +2224,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -2260,7 +2240,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "irate(node_network_transmit_bytes_total[$__rate_interval])*8",
@@ -2292,7 +2272,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2338,9 +2318,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2353,7 +2331,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2375,7 +2353,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2421,9 +2399,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2436,7 +2412,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2458,7 +2434,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2504,9 +2480,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2519,7 +2493,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2541,7 +2515,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2587,9 +2561,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2602,7 +2574,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2624,7 +2596,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2670,9 +2642,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2685,7 +2655,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2707,7 +2677,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2753,9 +2723,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2768,7 +2736,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2790,7 +2758,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2871,7 +2839,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_execution_ledger_num_commits{job=~\"${net}.*\"}[60s])",
@@ -2888,7 +2856,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2969,7 +2937,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_execution_ledger_num_tx_commits{job=~\"${net}.*\"}[60s])",
@@ -2986,7 +2954,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3067,7 +3035,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_consensus_events_local_timeout{job=~\"${net}.*\"}[60s])",
@@ -3084,7 +3052,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3165,7 +3133,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_bft_txpool_create_proposal{job=~\"${net}.*\"}[60s])",
@@ -3182,7 +3150,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3263,7 +3231,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_consensus_events_rx_execution_lagging{job=~\"${net}.*\"}[60s])",
@@ -3280,7 +3248,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3361,7 +3329,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_consensus_events_failed_ts_validation{job=~\"${net}.*\"}[60s])",
@@ -3378,7 +3346,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3459,7 +3427,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_blocksync_events_payload_response_successful{job=~\"${net}.*\"}[60s])",
@@ -3475,7 +3443,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3557,7 +3525,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "1-monad_statesync_progress_estimate{job=~\"${net}.*\"}/monad_statesync_last_target{job=~\"${net}.*\"}",
@@ -3638,9 +3606,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3654,7 +3620,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -3676,7 +3642,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Total RootFS",
       "fieldConfig": {
@@ -3731,9 +3697,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3747,7 +3711,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -3769,7 +3733,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Total RootFS",
       "fieldConfig": {
@@ -3824,9 +3788,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3840,7 +3802,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -3866,7 +3828,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Total RootFS",
       "fieldConfig": {
@@ -3921,9 +3883,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3937,7 +3897,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -3963,7 +3923,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -4012,9 +3972,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -4027,7 +3985,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -4049,7 +4007,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -4095,9 +4053,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -4110,7 +4066,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -4132,7 +4088,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -4532,12 +4488,7 @@
       "id": 42,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
+          "calcs": ["mean", "lastNotNull", "max", "min"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -4553,7 +4504,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -4570,7 +4521,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -4592,7 +4543,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -4992,12 +4943,7 @@
       "id": 44,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
+          "calcs": ["mean", "lastNotNull", "max", "min"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -5013,7 +4959,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5031,7 +4977,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5054,7 +5000,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -5454,12 +5400,7 @@
       "id": 45,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
+          "calcs": ["mean", "lastNotNull", "max", "min"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -5475,7 +5416,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5493,7 +5434,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5516,7 +5457,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -5905,12 +5846,7 @@
       "id": 46,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
+          "calcs": ["mean", "lastNotNull", "max", "min"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -5926,7 +5862,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5966,6 +5902,19 @@
         ],
         "query": "otel-collector",
         "type": "textbox"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "",
+          "value": "$datasource"
+        },
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
       }
     ]
   },

--- a/grafana/provisioning/dashboards/monad-monitoring-v3.json
+++ b/grafana/provisioning/dashboards/monad-monitoring-v3.json
@@ -38,7 +38,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Busy state of all CPU cores together",
       "fieldConfig": {
@@ -91,9 +91,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -107,7 +105,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -177,9 +175,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -193,7 +189,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -264,9 +260,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -280,7 +274,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -341,9 +335,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -357,7 +349,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -374,7 +366,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "100 - ((node_memory_MemAvailable_bytes * 100) / node_memory_MemTotal_bytes)",
@@ -443,9 +435,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -459,7 +449,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -480,7 +470,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Used Root FS",
       "fieldConfig": {
@@ -533,9 +523,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -549,7 +537,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -620,9 +608,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -636,7 +622,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -703,9 +689,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -719,7 +703,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -786,9 +770,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -802,7 +784,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -869,9 +851,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -885,7 +865,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -1094,7 +1074,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -1111,7 +1091,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1128,7 +1108,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1144,7 +1124,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1160,7 +1140,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1176,7 +1156,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1634,7 +1614,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -1651,7 +1631,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "node_memory_MemTotal_bytes - node_memory_MemFree_bytes - (node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes  )",
@@ -1666,7 +1646,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes",
@@ -1680,7 +1660,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "node_memory_MemFree_bytes",
@@ -1694,7 +1674,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "(node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes)",
@@ -1796,7 +1776,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -2244,7 +2224,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -2260,7 +2240,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "irate(node_network_transmit_bytes_total[$__rate_interval])*8",
@@ -2292,7 +2272,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2338,9 +2318,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2353,7 +2331,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2375,7 +2353,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2421,9 +2399,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2436,7 +2412,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2458,7 +2434,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2504,9 +2480,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2519,7 +2493,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2541,7 +2515,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2587,9 +2561,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2602,7 +2574,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2624,7 +2596,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2670,9 +2642,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2685,7 +2655,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2707,7 +2677,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2753,9 +2723,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -2768,7 +2736,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2790,7 +2758,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2871,7 +2839,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_execution_ledger_num_commits{job=~\"${net}.*\"}[60s])",
@@ -2888,7 +2856,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2969,7 +2937,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_execution_ledger_num_tx_commits{job=~\"${net}.*\"}[60s])",
@@ -2986,7 +2954,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3067,7 +3035,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_consensus_events_local_timeout{job=~\"${net}.*\"}[60s])",
@@ -3084,7 +3052,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3165,7 +3133,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_bft_txpool_create_proposal{job=~\"${net}.*\"}[60s])",
@@ -3182,7 +3150,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3263,7 +3231,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_consensus_events_rx_execution_lagging{job=~\"${net}.*\"}[60s])",
@@ -3280,7 +3248,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3361,7 +3329,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_consensus_events_failed_ts_validation{job=~\"${net}.*\"}[60s])",
@@ -3378,7 +3346,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3459,7 +3427,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_blocksync_events_payload_response_successful{job=~\"${net}.*\"}[60s])",
@@ -3475,7 +3443,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3557,7 +3525,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "1-monad_statesync_progress_estimate{job=~\"${net}.*\"}/monad_statesync_last_target{job=~\"${net}.*\"}",
@@ -3573,7 +3541,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Shows your success on proposing or missing blocks",
       "fieldConfig": {
@@ -3611,9 +3579,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3643,9 +3609,7 @@
           "options": {
             "fields": {
               "Value": {
-                "aggregations": [
-                  "min"
-                ],
+                "aggregations": ["min"],
                 "operation": "aggregate"
               },
               "round": {
@@ -3676,9 +3640,7 @@
           "options": {
             "fields": {
               "Value (min)": {
-                "aggregations": [
-                  "count"
-                ],
+                "aggregations": ["count"],
                 "operation": "aggregate"
               },
               "round": {
@@ -3724,7 +3686,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Shows your success on proposing or missing blocks",
       "fieldConfig": {
@@ -3763,9 +3725,7 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -3795,9 +3755,7 @@
           "options": {
             "fields": {
               "Value": {
-                "aggregations": [
-                  "min"
-                ],
+                "aggregations": ["min"],
                 "operation": "aggregate"
               },
               "round": {
@@ -3824,9 +3782,7 @@
           "options": {
             "fields": {
               "Value (min)": {
-                "aggregations": [
-                  "count"
-                ],
+                "aggregations": ["count"],
                 "operation": "aggregate"
               },
               "round": {
@@ -3872,7 +3828,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Shows your success on proposing or missing blocks",
       "fieldConfig": {
@@ -3944,9 +3900,7 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "show": false
         },
         "showHeader": true,
@@ -3975,9 +3929,7 @@
           "options": {
             "fields": {
               "Value": {
-                "aggregations": [
-                  "min"
-                ],
+                "aggregations": ["min"],
                 "operation": "aggregate"
               },
               "round": {
@@ -4114,9 +4066,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -4130,7 +4080,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -4152,7 +4102,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Total RootFS",
       "fieldConfig": {
@@ -4207,9 +4157,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -4223,7 +4171,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -4245,7 +4193,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Total RootFS",
       "fieldConfig": {
@@ -4300,9 +4248,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -4316,7 +4262,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -4342,7 +4288,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Total RootFS",
       "fieldConfig": {
@@ -4397,9 +4343,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -4413,7 +4357,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -4439,7 +4383,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -4488,9 +4432,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -4503,7 +4445,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -4525,7 +4467,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -4571,9 +4513,7 @@
         "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
+          "calcs": ["last"],
           "fields": "",
           "values": false
         },
@@ -4586,7 +4526,7 @@
       "targets": [
         {
           "datasource": {
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -4608,7 +4548,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -5008,12 +4948,7 @@
       "id": 42,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
+          "calcs": ["mean", "lastNotNull", "max", "min"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -5029,7 +4964,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5046,7 +4981,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5068,7 +5003,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -5468,12 +5403,7 @@
       "id": 44,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
+          "calcs": ["mean", "lastNotNull", "max", "min"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -5489,7 +5419,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5507,7 +5437,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5530,7 +5460,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -5930,12 +5860,7 @@
       "id": 45,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
+          "calcs": ["mean", "lastNotNull", "max", "min"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -5951,7 +5876,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5969,7 +5894,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -5992,7 +5917,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -6381,12 +6306,7 @@
       "id": 46,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
+          "calcs": ["mean", "lastNotNull", "max", "min"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -6402,7 +6322,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -6442,6 +6362,19 @@
         ],
         "query": "otel-collector",
         "type": "textbox"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "",
+          "value": "$datasource"
+        },
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
       }
     ]
   },

--- a/grafana/provisioning/dashboards/monad-monitoring.json
+++ b/grafana/provisioning/dashboards/monad-monitoring.json
@@ -36,7 +36,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "description": "Busy state of all CPU cores together",
       "fieldConfig": {
@@ -90,9 +90,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -106,7 +104,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -177,9 +175,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -193,7 +189,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -265,9 +261,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -281,7 +275,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -344,9 +338,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -360,7 +352,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -377,7 +369,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "100 - ((node_memory_MemAvailable_bytes * 100) / node_memory_MemTotal_bytes)",
@@ -447,9 +439,7 @@
         "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -463,7 +453,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -531,9 +521,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -547,7 +535,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -616,9 +604,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -632,7 +618,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -704,9 +690,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -720,7 +704,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -790,9 +774,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -806,7 +788,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -874,9 +856,7 @@
         "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -890,7 +870,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -1099,7 +1079,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -1116,7 +1096,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1133,7 +1113,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1149,7 +1129,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1165,7 +1145,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1181,7 +1161,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1639,7 +1619,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -1656,7 +1636,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "node_memory_MemTotal_bytes - node_memory_MemFree_bytes - (node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes  )",
@@ -1671,7 +1651,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes",
@@ -1685,7 +1665,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "node_memory_MemFree_bytes",
@@ -1699,7 +1679,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "(node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes)",
@@ -1801,7 +1781,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -2249,7 +2229,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -2265,7 +2245,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "Prometheus"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "irate(node_network_transmit_bytes_total[$__rate_interval])*8",
@@ -2297,7 +2277,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2377,7 +2357,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_execution_ledger_num_commits{job=~\"${net}.*\"}[60s])",
@@ -2394,7 +2374,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2474,7 +2454,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_execution_ledger_num_tx_commits{job=~\"${net}.*\"}[60s])",
@@ -2491,7 +2471,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2571,7 +2551,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_consensus_events_local_timeout{job=~\"${net}.*\"}[60s])",
@@ -2588,7 +2568,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2668,7 +2648,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_consensus_events_creating_empty_block_proposal{job=~\"${net}.*\"}[60s])",
@@ -2685,7 +2665,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2764,7 +2744,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_consensus_events_rx_execution_lagging{job=~\"${net}.*\"}[60s])",
@@ -2781,7 +2761,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2860,7 +2840,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_consensus_events_failed_ts_validation{job=~\"${net}.*\"}[60s])",
@@ -2877,7 +2857,7 @@
       "datasource": {
         "default": true,
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2956,7 +2936,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "rate(monad_state_blocksync_events_payload_response_successful{job=~\"${net}.*\"}[60s])",
@@ -2972,7 +2952,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P35E6C0425375C40D"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -3052,7 +3032,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P35E6C0425375C40D"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "1-monad_statesync_progress_estimate{job=~\"${net}.*\"}/monad_statesync_last_target{job=~\"${net}.*\"}",
@@ -3089,6 +3069,19 @@
         "query": "otel-collector",
         "skipUrlSync": false,
         "type": "textbox"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "",
+          "value": "$datasource"
+        },
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
       }
     ]
   },


### PR DESCRIPTION
I have an existing grafana/VictoriaMetrics stack for monitoring. By using a variable for the datastore it creates a dropdown of any prometheus-compatible datastores configured so that each chart doesn't need to be updated when importing to an existing environment