### PR TITLE
WIP: Add attributes for easier filtering

### DIFF
--- a/collector/otel-collector-config.yaml
+++ b/collector/otel-collector-config.yaml
@@ -9,10 +9,14 @@ receivers:
   prometheus:
     config:
       scrape_configs:
-      - job_name: 'otel-collector'
-        scrape_interval: 10s
-        static_configs:
-        - targets: ['127.0.0.1:8888']
+        - job_name: "otel-collector"
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["127.0.0.1:8888"]
+        - job_name: node
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["127.0.0.1:9100"]
 
 exporters:
   otlp:
@@ -34,12 +38,28 @@ processors:
     limit_mib: 1500
     spike_limit_mib: 512
     check_interval: 5s
+
+  resourcedetection:
+    detectors: [system]
+    system:
+      resource_attributes:
+        host.name:
+          enabled: true
+
+  attributes:
+    actions:
+      - key: monad_network
+        action: insert
+        value: testnet-2
+      - key: public_hostname
+        action: insert
+        value: testnet-2.example.com
 service:
   pipelines:
     metrics:
-      receivers: [otlp]
-      exporters: [prometheus,otlp]
-      processors: [batch]
+      receivers: [otlp, prometheus]
+      exporters: [prometheus, otlp]
+      processors: [attributes, resourcedetection, batch]
     traces:
       receivers: [otlp]
       processors: [batch]

--- a/prometheus/prometheus.yaml
+++ b/prometheus/prometheus.yaml
@@ -3,7 +3,3 @@ scrape_configs:
     scrape_interval: 10s
     static_configs:
       - targets: ["otel-collector:8889"]
-  - job_name: node
-    scrape_interval: 10s
-    static_configs:
-      - targets: ['node-exporter:9100']


### PR DESCRIPTION
Adds attributes for monad_network, public_hostname, and host_name, populating host_name using resourcedetection processor.

This allows for simpler filtering logic on the grafana dashboards and is not reliant on prometheus job names.

Moves scrape job of monad's metrics endpoint to OTEL